### PR TITLE
Adding status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SemanticDB to LSIF converter
+# SemanticDB to LSIF converter ![](https://img.shields.io/badge/status-development-yellow)
 
 Visit https://lsif.dev/ to learn about LSIF.
 


### PR DESCRIPTION
Status badge helps inform users of the state of the tool, the badge should match status listed in: https://lsif.dev/