### PR TITLE
adds support for denoting other languages

### DIFF
--- a/internal/index/indexer.go
+++ b/internal/index/indexer.go
@@ -316,9 +316,14 @@ func (i *indexer) indexDbDefs(uri string, fi *fileInfo, proID uint64) (err error
 			i.defs[key] = def
 		}
 
+		var language string
+		if symbol.GetLanguage() != pb.Language_UNKNOWN_LANGUAGE {
+			language = strings.ToLower(symbol.GetLanguage().String())
+		}
+
 		contents := []protocol.MarkedString{
 			{
-				Language: "scala",
+				Language: language,
 				Value:    symbol.GetDisplayName(),
 			},
 		}


### PR DESCRIPTION
I am unsure of the behaviour when `Language == ""`, but assuming that just gets concat'd to the markdown string we generate, this should be fine :slightly_smiling_face: 