### PR TITLE
Remove use of ioutil package

### DIFF
--- a/cmd/lsif-semanticdb/main.go
+++ b/cmd/lsif-semanticdb/main.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin"
-	"github.com/sourcegraph/sourcegraph/enterprise/lib/codeintel/lsif/protocol"
 	"github.com/sourcegraph/lsif-semanticdb/internal/index"
 	"github.com/sourcegraph/lsif-semanticdb/internal/log"
+	"github.com/sourcegraph/sourcegraph/enterprise/lib/codeintel/lsif/protocol"
 )
 
 const version = "0.4.1"

--- a/internal/index/helper.go
+++ b/internal/index/helper.go
@@ -1,8 +1,8 @@
 package index
 
 import (
-	"github.com/sourcegraph/sourcegraph/enterprise/lib/codeintel/lsif/protocol"
 	pb "github.com/sourcegraph/lsif-semanticdb/internal/proto"
+	"github.com/sourcegraph/sourcegraph/enterprise/lib/codeintel/lsif/protocol"
 )
 
 func convertRange(r *pb.Range) (start protocol.Pos, end protocol.Pos) {

--- a/internal/index/indexer.go
+++ b/internal/index/indexer.go
@@ -3,7 +3,6 @@ package index
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -107,7 +106,7 @@ func (i *indexer) loadDatabases() error {
 }
 
 func (i *indexer) loadDatabase(path string) error {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/internal/proto/semanticdb.pb.go
+++ b/internal/proto/semanticdb.pb.go
@@ -7,11 +7,12 @@
 package scala_meta_internal_semanticdb
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)